### PR TITLE
New patchfile and makefile allowing MacOS compilation.

### DIFF
--- a/MacOS.patch
+++ b/MacOS.patch
@@ -1,0 +1,269 @@
+Only in ./src/: MacOS.patch
+diff -c -r ./src/VisDrawer.cpp ../p4vasp-0.3.31/src/VisDrawer.cpp
+*** ./src/VisDrawer.cpp	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/VisDrawer.cpp	Thu Apr 26 16:30:44 2018
+***************
+*** 25,31 ****
+  #include <p4vasp/Exceptions.h>
+  #include <stdio.h>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  
+  const char *VisDrawer::getClassName(){return "VisDrawer";}
+  
+--- 25,31 ----
+  #include <p4vasp/Exceptions.h>
+  #include <stdio.h>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  
+  const char *VisDrawer::getClassName(){return "VisDrawer";}
+  
+diff -c -r ./src/VisIsosurfaceDrawer.cpp ../p4vasp-0.3.31/src/VisIsosurfaceDrawer.cpp
+*** ./src/VisIsosurfaceDrawer.cpp	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/VisIsosurfaceDrawer.cpp	Thu Apr 26 16:32:32 2018
+***************
+*** 24,30 ****
+  #include <p4vasp/VisIsosurfaceDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include <stdio.h>
+  #include <string.h>
+  #include <p4vasp/vecutils.h>
+--- 24,30 ----
+  #include <p4vasp/VisIsosurfaceDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include <stdio.h>
+  #include <string.h>
+  #include <p4vasp/vecutils.h>
+diff -c -r ./src/VisMain.cpp ../p4vasp-0.3.31/src/VisMain.cpp
+*** ./src/VisMain.cpp	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/VisMain.cpp	Thu Apr 26 16:30:26 2018
+***************
+*** 28,34 ****
+  #include <FL/Fl.H>
+  #include <FL/Fl_Gl_Window.H>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include <p4vasp/VisFLWindow.h>
+  
+  THREAD(Vis_thread);
+--- 28,34 ----
+  #include <FL/Fl.H>
+  #include <FL/Fl_Gl_Window.H>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include <p4vasp/VisFLWindow.h>
+  
+  THREAD(Vis_thread);
+diff -c -r ./src/VisNavDrawer.cpp ../p4vasp-0.3.31/src/VisNavDrawer.cpp
+*** ./src/VisNavDrawer.cpp	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/VisNavDrawer.cpp	Thu Apr 26 16:31:02 2018
+***************
+*** 24,30 ****
+  #include <p4vasp/VisNavDrawer.h>
+  #include <FL/Fl.H>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include <p4vasp/vecutils.h>
+  #include <p4vasp/Exceptions.h>
+  
+--- 24,30 ----
+  #include <p4vasp/VisNavDrawer.h>
+  #include <FL/Fl.H>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include <p4vasp/vecutils.h>
+  #include <p4vasp/Exceptions.h>
+  
+diff -c -r ./src/VisPrimitiveDrawer.cpp ../p4vasp-0.3.31/src/VisPrimitiveDrawer.cpp
+*** ./src/VisPrimitiveDrawer.cpp	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/VisPrimitiveDrawer.cpp	Thu Apr 26 16:32:47 2018
+***************
+*** 24,30 ****
+  #include <p4vasp/VisPrimitiveDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include <stdio.h>
+  #include <p4vasp/Exceptions.h>
+  
+--- 24,30 ----
+  #include <p4vasp/VisPrimitiveDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include <stdio.h>
+  #include <p4vasp/Exceptions.h>
+  
+diff -c -r ./src/VisStructureArrowsDrawer.cpp ../p4vasp-0.3.31/src/VisStructureArrowsDrawer.cpp
+*** ./src/VisStructureArrowsDrawer.cpp	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/VisStructureArrowsDrawer.cpp	Thu Apr 26 16:32:01 2018
+***************
+*** 24,30 ****
+  #include <p4vasp/VisStructureArrowsDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include <stdio.h>
+  #include <string.h>
+  #include <p4vasp/vecutils.h>
+--- 24,30 ----
+  #include <p4vasp/VisStructureArrowsDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include <stdio.h>
+  #include <string.h>
+  #include <p4vasp/vecutils.h>
+diff -c -r ./src/VisStructureDrawer.cpp ../p4vasp-0.3.31/src/VisStructureDrawer.cpp
+*** ./src/VisStructureDrawer.cpp	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/VisStructureDrawer.cpp	Thu Apr 26 16:31:25 2018
+***************
+*** 24,30 ****
+  #include <p4vasp/VisStructureDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include <stdio.h>
+  #include <p4vasp/vecutils.h>
+  #include <p4vasp/VisBackEvent.h>
+--- 24,30 ----
+  #include <p4vasp/VisStructureDrawer.h>
+  #include <math.h>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include <stdio.h>
+  #include <p4vasp/vecutils.h>
+  #include <p4vasp/VisBackEvent.h>
+Only in ./src/: cp4vasp.pyc
+diff -c -r ./src/fltk-config.py ../p4vasp-0.3.31/src/fltk-config.py
+*** ./src/fltk-config.py	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/fltk-config.py	Thu Apr 26 16:39:11 2018
+***************
+*** 9,18 ****
+      os.system("%s >fltk-config.tmp"%cmd)
+      return open("fltk-config.tmp").read()
+  
+! if 0 and strip(run("fltk-config --version")) in ["1.1.5","1.1.6","1.1.7","1.1.8"]:
+!     print run("fltk-config "+" ".join(sys.argv[1:]))
+! else:
+!     if not os.path.exists("../ext/bin/fltk-config"):
+!         os.system("cd ../ext; bash build-fltk.sh >build-fltk.log 2>build-fltk.err")
+!     print run("../ext/bin/fltk-config "+" ".join(sys.argv[1:]))
+      
+--- 9,19 ----
+      os.system("%s >fltk-config.tmp"%cmd)
+      return open("fltk-config.tmp").read()
+  
+! print run("fltk-config "+" ".join(sys.argv[1:]))
+! #if 0 and strip(run("fltk-config --version")) in ["1.1.5","1.1.6","1.1.7","1.1.8","1.3.4"]:
+! #    print run("fltk-config "+" ".join(sys.argv[1:]))
+! #else:
+! #    if not os.path.exists("../ext/bin/fltk-config"):
+! #        os.system("cd ../ext; bash build-fltk.sh >build-fltk.log 2>build-fltk.err")
+! #    print run("../ext/bin/fltk-config "+" ".join(sys.argv[1:]))
+      
+diff -c -r ./src/include/p4vasp/VisFLWindow.h ../p4vasp-0.3.31/src/include/p4vasp/VisFLWindow.h
+*** ./src/include/p4vasp/VisFLWindow.h	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/include/p4vasp/VisFLWindow.h	Thu Apr 26 16:28:42 2018
+***************
+*** 25,31 ****
+  
+  #include <FL/Fl_Gl_Window.H>
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include "VisWindow.h"
+  
+  class VisFLWindow : public Fl_Gl_Window{
+--- 25,31 ----
+  
+  #include <FL/Fl_Gl_Window.H>
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include "VisWindow.h"
+  
+  class VisFLWindow : public Fl_Gl_Window{
+diff -c -r ./src/include/p4vasp/VisIsosurfaceDrawer.h ../p4vasp-0.3.31/src/include/p4vasp/VisIsosurfaceDrawer.h
+*** ./src/include/p4vasp/VisIsosurfaceDrawer.h	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/include/p4vasp/VisIsosurfaceDrawer.h	Thu Apr 26 16:32:16 2018
+***************
+*** 26,32 ****
+  #include "Chgcar.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  
+  #ifndef VisWindow
+  class VisWindow;
+--- 26,32 ----
+  #include "Chgcar.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  
+  #ifndef VisWindow
+  class VisWindow;
+diff -c -r ./src/include/p4vasp/VisPrimitiveDrawer.h ../p4vasp-0.3.31/src/include/p4vasp/VisPrimitiveDrawer.h
+*** ./src/include/p4vasp/VisPrimitiveDrawer.h	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/include/p4vasp/VisPrimitiveDrawer.h	Thu Apr 26 16:29:32 2018
+***************
+*** 25,31 ****
+  #include "VisDrawer.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  
+  #ifndef VisWindow
+  class VisWindow;
+--- 25,31 ----
+  #include "VisDrawer.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  
+  #ifndef VisWindow
+  class VisWindow;
+diff -c -r ./src/include/p4vasp/VisStructureArrowsDrawer.h ../p4vasp-0.3.31/src/include/p4vasp/VisStructureArrowsDrawer.h
+*** ./src/include/p4vasp/VisStructureArrowsDrawer.h	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/include/p4vasp/VisStructureArrowsDrawer.h	Thu Apr 26 16:31:44 2018
+***************
+*** 26,32 ****
+  #include "VisStructureDrawer.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  
+  #ifndef VisWindow
+  class VisWindow;
+--- 26,32 ----
+  #include "VisStructureDrawer.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  
+  #ifndef VisWindow
+  class VisWindow;
+diff -c -r ./src/include/p4vasp/VisStructureDrawer.h ../p4vasp-0.3.31/src/include/p4vasp/VisStructureDrawer.h
+*** ./src/include/p4vasp/VisStructureDrawer.h	Fri Apr 27 09:53:39 2018
+--- ../p4vasp-0.3.31/src/include/p4vasp/VisStructureDrawer.h	Thu Apr 26 16:29:57 2018
+***************
+*** 25,31 ****
+  #include "VisPrimitiveDrawer.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <GL/glu.h>
+  #include "AtomInfo.h"
+  #include "Structure.h"
+  
+--- 25,31 ----
+  #include "VisPrimitiveDrawer.h"
+  #include "threads.h"
+  #include <FL/gl.h>
+! #include <openGL/glu.h>
+  #include "AtomInfo.h"
+  #include "Structure.h"
+  

--- a/Makefile.MacOS
+++ b/Makefile.MacOS
@@ -13,16 +13,12 @@
 # BINDIR        - where the executable will go (e.g. /usr/bin)       #
 ######################################################################
 
-ROOT=/opt/local
-P4VASP_HOME   = $(ROOT)/lib/p4vasp
-PYTHON_HOME   = $(ROOT)/lib/python2.4
-SITE_PACKAGES = $(PYTHON_HOME)/site-packages
-INCLUDEDIR    = $(ROOT)/include
-LIBDIR        = $(ROOT)/lib
-BINDIR        = $(ROOT)/bin
+-include install/Configuration.mk
 
 P4VCONFIG     = lib/p4vasp/config.py
 VINFO         = vinfo.py
+SETENVIRONMENT= setenvironment.sh
+P4V           = p4v
 
 .PHONY: p4vasp
 .PHONY: doc
@@ -39,16 +35,46 @@ VINFO         = vinfo.py
 .PHONY: uninstall_gui
 .PHONY: uninstall_devel
 .PHONY: uninstall
+.PHONY: uninstallsh
 .PHONY: p4vasp_config
-
+.PHONY: setenvironment
+.PHONY: launcher
+.PHONY: appletlist
 
 all: p4vasp
-p4vasp: p4vasp_config uninstall.sh
-	cd odpdom && $(MAKE) libODP.a	
+local:
+	cd install && python configure.py local
+config:
+	cd install && python configure.py
+p4vasp: p4vasp_config uninstallsh appletlist
+	cd odpdom && $(MAKE) libODP.a
 	cd src && $(MAKE)
 p4vasp_config:
 	echo "p4vasp_home='$(P4VASP_HOME)'" >$(P4VCONFIG)
 	cat $(VINFO) >> $(P4VCONFIG)
+devver:
+	echo "name       ='p4vasp-devel'" > $(VINFO)
+	echo "version    ='DEVELOPMENT'" >> $(VINFO)
+	echo "release    ='1'" >> $(VINFO)
+	echo "build_date ='`date`'" >> $(VINFO)
+setenvironment:
+	echo "# set p4vasp environment variables"   >  $(SETENVIRONMENT)
+	echo "export PATH=\$$PATH:"$(BINDIR) >> $(SETENVIRONMENT)
+launcher:
+	echo "#!`which sh`" >$(P4V)
+	echo "export LD_PRELOAD=libstdc++.so.6" >>$(P4V)
+	echo "export PYTHONPATH=\$$PYTHONPATH:"$(SITE_PACKAGES) >>$(P4V)
+	echo "#export APPMENU_DISPLAY_BOTH=1" >>$(P4V)
+	echo "export UBUNTU_MENUPROXY=0" >>$(P4V)
+	echo "export P4VASP_HOME="$(P4VASP_HOME) >> $(P4V)
+	echo "exec python "$(BINDIR)"/p4v.py \"\$$@\"" >>$(P4V)
+appletlist:
+	cd install && python makeappletlist.py
+bashrc:setenvironment
+	echo "" >> ~/.bashrc
+	cat $(SETENVIRONMENT) >> ~/.bashrc
+fltk:
+	cd ext && sh build-fltk.sh
 doc:
 	cd doc && $(MAKE)
 clean_p4vasp:
@@ -64,20 +90,61 @@ cleanall_p4vasp:
 	rm -f lib/p4vasp/config.py
 	rm -f lib/p4vasp/*.pyc
 	rm -f lib/p4vasp/*.pyo
+	rm -f lib/p4vasp/*.bak
+	rm -f lib/p4vasp/*~
+	rm -f lib/p4vasp/paint3d/*.pyc
+	rm -f lib/p4vasp/paint3d/*.pyo
+	rm -f lib/p4vasp/paint3d/*.bak
+	rm -f lib/p4vasp/paint3d/*~
+	rm -f lib/p4vasp/export/*.pyc
+	rm -f lib/p4vasp/export/*.pyo
+	rm -f lib/p4vasp/export/*.bak
+	rm -f lib/p4vasp/export/*~
 	rm -f lib/p4vasp/applet/*.pyc
 	rm -f lib/p4vasp/applet/*.pyo
+	rm -f lib/p4vasp/applet/*.bak
+	rm -f lib/p4vasp/applet/*~
+	rm -f lib/p4vasp/applet/appletlist.py
 	rm -f lib/p4vasp/piddle/*.pyc
 	rm -f lib/p4vasp/piddle/*.pyo
+	rm -f lib/p4vasp/piddle/*.bak
+	rm -f lib/p4vasp/piddle/*~
 	rm -f lib/p4vasp/piddle/piddleGTKp4/*.pyc
 	rm -f lib/p4vasp/piddle/piddleGTKp4/*.pyo
+	rm -f lib/p4vasp/piddle/piddleGTKp4/*.bak
+	rm -f lib/p4vasp/piddle/piddleGTKp4/*~
+	rm -f lib/p4vasp/piddle/piddleGTK2p4/*.pyc
+	rm -f lib/p4vasp/piddle/piddleGTK2p4/*.pyo
+	rm -f lib/p4vasp/piddle/piddleGTK2p4/*.bak
+	rm -f lib/p4vasp/piddle/piddleGTK2p4/*~
+	rm -f test/*.pyc
+	rm -f test/*.pyo
+	rm -f test/*.bak
+	rm -f test/*~
+	rm -f utils/*.pyc
+	rm -f utils/*.pyo
+	rm -f utils/*.bak
+	rm -f utils/*~
+	rm -f install/*.pyc
+	rm -f install/*.pyo
+	rm -f install/*.bak
+	rm -f install/*~
 	rm -f log
 	rm -f p4vasp.log
+	rm -f p4v
+	rm -f install/Configuration.mk
+	rm -f *~
+	rm -f *.pyc
+	rm -f *.pyo
+	rm -f *.bak
 	cd src && $(MAKE) cleanall
 cleanall_odpdom:
 	cd odpdom && $(MAKE) cleanall
-clean: clean_p4vasp clean_odpdom
-cleanall: cleanall_p4vasp cleanall_odpdom cleanall_doc
+cleanall_ext:
+	cd ext && sh clean.sh
 
+clean: clean_p4vasp clean_odpdom
+cleanall: cleanall_p4vasp cleanall_odpdom cleanall_doc cleanall_ext
 
 install_pythonpkg:p4vasp
 	mkdir -p $(SITE_PACKAGES)/p4vasp
@@ -86,22 +153,24 @@ install_pythonpkg:p4vasp
 	chmod    644 $(SITE_PACKAGES)/p4vasp/*
 	chmod -R 755 $(SITE_PACKAGES)/p4vasp/applet
 	chmod -R 644 $(SITE_PACKAGES)/p4vasp/applet/*
-	chmod -R 755 $(SITE_PACKAGES)/p4vasp/piddle	
+	chmod -R 755 $(SITE_PACKAGES)/p4vasp/paint3d
+	chmod -R 644 $(SITE_PACKAGES)/p4vasp/paint3d/*
+	chmod -R 755 $(SITE_PACKAGES)/p4vasp/export
+	chmod -R 644 $(SITE_PACKAGES)/p4vasp/export/*
+	chmod -R 755 $(SITE_PACKAGES)/p4vasp/piddle
 	cd src; install -m755  cp4vasp.py _cp4vasp.so $(SITE_PACKAGES); cd ..
 
-	
-install_gui:install_pythonpkg uninstall.sh
+install_gui:install_pythonpkg uninstallsh launcher
 	mkdir -p     $(P4VASP_HOME)
-	
 	cp -R data   $(P4VASP_HOME)
 	cp -R utils  $(P4VASP_HOME)
 	chmod -R 755 $(P4VASP_HOME)/data
 	chmod    644 $(P4VASP_HOME)/data/*
-	chmod    755 $(P4VASP_HOME)/data/glade 
+	chmod    755 $(P4VASP_HOME)/data/glade
 	chmod    644 $(P4VASP_HOME)/data/glade/*
 	chmod    755 $(P4VASP_HOME)/data/glade/pixmaps
 	chmod    644 $(P4VASP_HOME)/data/glade/pixmaps/*
-	chmod    755 $(P4VASP_HOME)/data/glade2 
+	chmod    755 $(P4VASP_HOME)/data/glade2
 	chmod    644 $(P4VASP_HOME)/data/glade2/*
 	chmod    755 $(P4VASP_HOME)/data/glade2/pixmaps
 	chmod    644 $(P4VASP_HOME)/data/glade2/pixmaps/*
@@ -109,18 +178,21 @@ install_gui:install_pythonpkg uninstall.sh
 	chmod    644 $(P4VASP_HOME)/data/graphs/*
 	chmod    755 $(P4VASP_HOME)/data/images
 	chmod    644 $(P4VASP_HOME)/data/images/*
+	chmod    755 $(P4VASP_HOME)/data/database
+	chmod    644 $(P4VASP_HOME)/data/database/*
 	chmod -R 755 $(P4VASP_HOME)/utils
 
 	install -m755 uninstall.sh $(P4VASP_HOME)/uninstall.sh
 	install -m755 diagnostic.py $(P4VASP_HOME)/diagnostic.py
-	
-	install -m644 BUGS FAQS LICENSE README Required.txt $(P4VASP_HOME)
+
+	install -m644 BUGS FAQS LICENSE README $(P4VASP_HOME)
+	mkdir -p $(BINDIR)
 	install -d -m755     $(BINDIR)
 	install -m755 p4v.py $(BINDIR)/p4v.py
-	install -m755 p4v.py $(BINDIR)/p4v
+	install -m755 $(P4V) $(BINDIR)/$(P4V)
 
 install_doc:
-	mkdir -p       $(P4VASP_HOME)	
+	mkdir -p       $(P4VASP_HOME)
 	cp -R doc      $(P4VASP_HOME)
 	chmod -R 755   $(P4VASP_HOME)/doc
 	chmod    644   $(P4VASP_HOME)/doc/*
@@ -130,23 +202,24 @@ install_doc:
 	chmod -R 755   $(P4VASP_HOME)/doc/api/python
 	chmod -R 755   $(P4VASP_HOME)/doc/intro
 	chmod    644   $(P4VASP_HOME)/doc/intro/*
-		
+
 install_devel:install_pythonpkg
+	mkdir -p $(LIBDIR)
 	mkdir -p $(INCLUDEDIR)/ODP
 	mkdir -p $(INCLUDEDIR)/p4vasp
-	cp -R odpdom/include/ODP $(INCLUDEDIR)	
+	cp -R odpdom/include/ODP $(INCLUDEDIR)
 	cp -R src/include/p4vasp $(INCLUDEDIR)
 	chmod 755 $(INCLUDEDIR)/ODP
 	chmod 755 $(INCLUDEDIR)/p4vasp
 	chmod 644 $(INCLUDEDIR)/ODP/*
 	chmod 644 $(INCLUDEDIR)/p4vasp/*
 	cp src/libp4vasp.a $(LIBDIR)
-	chmod 644 $(LIBDIR)/libp4vasp.a	
+	chmod 644 $(LIBDIR)/libp4vasp.a
 	cp odpdom/libODP.a $(LIBDIR)
-	chmod 644 $(LIBDIR)/libODP.a	
-install:install_gui install_devel install_doc
+	chmod 644 $(LIBDIR)/libODP.a
+install:install_gui install_devel
 
-uninstall.sh:
+uninstallsh:
 	echo "#!/bin/sh" >uninstall.sh
 	echo "rm -Rf $(SITE_PACKAGES)/p4vasp" >>uninstall.sh
 	echo "rm -Rf $(SITE_PACKAGES)/cp4vasp.py" >>uninstall.sh
@@ -162,16 +235,15 @@ uninstall_pythonpkg:
 	rm -Rf $(SITE_PACKAGES)/p4vasp
 	rm -Rf $(SITE_PACKAGES)/cp4vasp.py
 	rm -Rf $(SITE_PACKAGES)/_cp4vasp.so
-	
+
 uninstall_gui:
 	rm -Rf $(P4VASP_HOME)
 	rm -f  $(BINDIR)/p4v.py
 	rm -f  $(BINDIR)/p4v
-	
+
 uninstall_devel:
 	rm -Rf $(INCLUDEDIR)/ODP
 	rm -Rf $(INCLUDEDIR)/p4vasp
-	rm -Rf $(LIBDIR)/libp4vasp.a 
+	rm -Rf $(LIBDIR)/libp4vasp.a
 	rm -Rf $(LIBDIR)/libODP.a
 uninstall:uninstall_gui uninstall_devel uninstall_pythonpkg
-

--- a/README
+++ b/README
@@ -67,6 +67,35 @@ x) If something goes wrong
    - We can try to help you if you visit forum at www.p4vasp.at, please provide us with the output from diagnostic.py.
 
 
+
+Installation (MacOs)
+--------------------------
+0) You will need X11 and the command-line tools for Xcode installed.
+   For Xquratz, visit: 			https://www.xquartz.org/
+   For command-line tools: 		$ xcode-select --install
+
+
+1) For FLTK installation, we use homebrew's fltk:
+   Install homebrew: 			$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+   Install fltk: 			$ brew install fltk
+
+2) Install other necessary library:	$ brew install python@2 pip gcc gtk+ pygtk —with-libglade && pip install pyopengl numpy
+
+3) Apply patch to the sourcefile:	$ patch -p0 -i MacOS.patch
+
+5) Copy the Makefile.MacOS to Makefile in the p4vasp root directory and in the src
+   directory:
+   cp Makefile.MacOS Makefile
+   cp src/Makefile.MacOS src/Makefile
+
+6) Run make and install:
+   make local; make; make install
+
+7) The executable should located at ~/p4vasp/bin
+
+
+
+
 Starting:
 --------------------------
 

--- a/README.MacOS
+++ b/README.MacOS
@@ -1,32 +1,20 @@
-NOTE, THIS DOCUMENT IS OUTDATED.
-THE PROCEDURE UNFORTUNATELY DOES NOT WORK AS DESCRIBED ANYMORE,
-THIS FILE IS PROVIDED IN A GOOD HOPE TO GIVE HINTS HOW TO INSTALL P4VASP ON OSX.
-PLEASE LET US KNOW IF YOU FIND A WAY HOW TO INSTALL ON OSX.
 
 
-Thanks to Dr. Daniel Knapp, here is a method to install p4vasp in MacOS:
-(Tested on Mac OS 10.4.5, all updates installed.)
+p4vasp compillation in MacOS:
+(Tested on Mac OS 10.13.4, all updates installed.)
 
-0) You will need X11 and all of the developer tools for OS X installed which
-   are included on your Tiger install discs but which are NOT installed by default.
+0) You will need X11 and the command-line tools for Xcode installed.
+   For Xquratz, visit: 			https://www.xquartz.org/
+   For command-line tools: 		$ xcode-select --install
+   
 
+1) For FLTK installation, we use homebrew's fltk:
+   Install homebrew: 			$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"   
+   Install fltk: 			$ brew install fltk
 
-1) Download and install FLTK (http://www.fltk.org, tested with v1.1.7):   
-   Simply download the tar.gz file and run make; make install. This will put a
-   working version of FLTK in /usr on my Mac.
-   (To be sure, try out the test programs.)
+2) Install other necessary library:	$ brew install python@2 pip gcc gtk+ pygtk —with-libglade && pip install pyopengl numpy
 
-2) Download and install the  DarwinPorts (http://darwinports.opendarwin.org)
-   This is a unix software installation program for the Mac. (DarwinPorts seems to be a bit
-   more up to date than Fink, but I did need to install the following in a particular
-   order in order for python to recognize all of the modules.)
-
-3) Use DarwinPorts to install gtk2 and glade libraries:
-   sudo port install gtk2 libglade2
-
-4) Used DarwinPorts to install py-gtk and python:
-   sudo port install py-gtk2
-   (Note that python2.4 will be installed along with py-gtk2)
+3) Apply patch to the sourcefile:	$ patch -p0 -i MacOS.patch
 
 5) Copy the Makefile.MacOS to Makefile in the p4vasp root directory and in the src
    directory:
@@ -34,8 +22,8 @@ Thanks to Dr. Daniel Knapp, here is a method to install p4vasp in MacOS:
    cp src/Makefile.MacOS src/Makefile   
 
 6) Run make and install:
-   make; make install
+   make local; make; make install
 
-7) Now p4v.py can then be run from any x-terminal (eg. xterm).
+7) The executable should located at ~/p4vasp/bin
 
 

--- a/README.MacOS
+++ b/README.MacOS
@@ -1,5 +1,3 @@
-
-
 p4vasp compillation in MacOS:
 (Tested on Mac OS 10.13.4, all updates installed.)
 
@@ -18,11 +16,12 @@ p4vasp compillation in MacOS:
 
 5) Copy the Makefile.MacOS to Makefile in the p4vasp root directory and in the src
    directory:
-   cp Makefile.MacOS Makefile
-   cp src/Makefile.MacOS src/Makefile   
+   					$ cp Makefile.MacOS Makefile
+					$ cp odpdom/Makefile.MacOS odpdom/Makefile
+   					$ cp src/Makefile.MacOS src/Makefile   
 
 6) Run make and install:
-   make local; make; make install
+   make local && make && make install
 
 7) The executable should located at ~/p4vasp/bin
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-p4vasp                                                        
+p4vasp
 ==========================
 
 Copyright notes:
@@ -64,6 +64,35 @@ x) If something goes wrong
    - Run the diagnostic.py script, it may provide you with some hints.
    - Check FAQ
    - We can try to help you if you visit forum at www.p4vasp.at, please provide us with the output from diagnostic.py.
+
+
+
+Installation (MacOs)
+--------------------------
+0) You will need X11 and the command-line tools for Xcode installed.
+   For Xquratz, visit: 			https://www.xquartz.org/
+   For command-line tools: 		$ xcode-select --install
+
+
+1) For FLTK installation, we use homebrew's fltk:
+   Install homebrew: 			$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+   Install fltk: 			$ brew install fltk
+
+2) Install other necessary library:	$ brew install python@2 pip gcc gtk+ pygtk —with-libglade && pip install pyopengl numpy
+
+3) Apply patch to the sourcefile:	$ patch -p0 -i MacOS.patch
+
+5) Copy the Makefile.MacOS to Makefile in the p4vasp root directory and in the src
+   directory:
+   cp Makefile.MacOS Makefile
+   cp src/Makefile.MacOS src/Makefile
+
+6) Run make and install:
+   make local; make; make install
+
+7) The executable should located at ~/p4vasp/bin
+
+
 
 
 Starting:

--- a/README.md
+++ b/README.md
@@ -22,44 +22,74 @@ Compilation Quickstart
 --------------------------
 
 For local installation run:
-
-   install-local.sh
+```
+   $ ./install-local.sh
+```
 
 For global installation run:
-
-   install.sh
-
+```
+   $ ./install.sh
+```
 
 Installation (local)
 --------------------------
 
 1) Make sure you have all the dependencies.
-   In Ubuntu you can do it with a supplied script:
-     install/install-ubuntu-dependencies.sh
+   In Ubuntu you can do it with a supplied script: `install/install-ubuntu-dependencies.sh`
 2) If there are previous versions of p4vasp, uninstall them.
-   You can do it with the uninstall.sh residing in the P4VASP_HOME directory.
-3) Unpack the file:                tar -xvzf p4vasp-x.x.x.tgz
-4) Change directory:               cd p4vasp-x.x.x
-5) Configure:                      make local
+   You can do it with the `uninstall.sh` residing in the P4VASP_HOME directory.
+3) Unpack the file:                
+```
+   $ tar -xvzf p4vasp-x.x.x.tgz
+```
+4) Change directory:               
+```
+   $ cd p4vasp-x.x.x
+```
+5) Configure:                      
+```
+   $ make local
+```
 6) check and adjust the paths in
-   install/Configuration.mk
-7) Install:                        make install
-8) Add path to p4v in the .bashrc  make bashrc
+```
+   $ install/Configuration.mk
+```
+7) Install:                        
+```
+   $ make install
+```
+8) Add path to p4v in the .bashrc  
+```
+   $ make bashrc
+```
 
 
 Installation (global)
 --------------------------
 
 1) Make sure you have all the dependencies.
-   In Ubuntu you can do it with a supplied script:
-     install/install-ubuntu-dependencies.sh
+   In Ubuntu you can do it with a supplied script: `install/install-ubuntu-dependencies.sh`
 2) Uninstall the old version (as root):
                         This usually (depending on your installation) can be done with an uninstall script:
-                        sudo bash /usr/lib/p4vasp/uninstall.sh
-3) Unpack the file:     tar -xvzf p4vasp-x.x.x.tgz
-4) Change directory:    cd p4vasp-x.x.x
-5) Configure:           make config
-6) install (as root):   make install
+```                        
+   $ sudo bash /usr/lib/p4vasp/uninstall.sh
+```
+3) Unpack the file:     
+```
+   $ tar -xvzf p4vasp-x.x.x.tgz
+```
+4) Change directory:    
+```
+   $ cd p4vasp-x.x.x
+```
+5) Configure:           
+```
+   $ make config
+```
+6) install (as root):   
+```
+   $ make install
+```
 x) If something goes wrong
    - Run the diagnostic.py script, it may provide you with some hints.
    - Check FAQ
@@ -67,30 +97,44 @@ x) If something goes wrong
 
 
 
-Installation (MacOs)
+Installation (MacOS)
 --------------------------
-0) You will need X11 and the command-line tools for Xcode installed.
-   For Xquratz, visit: 			https://www.xquartz.org/
-   For command-line tools: 		$ xcode-select --install
+1) You will need X11 and the command-line tools for Xcode.
+   For Xquratz(X11), visit [their website](https://www.xquartz.org/)
+   For command-line tools: 		
+```
+   $ xcode-select --install
+```
 
+2) For FLTK installation, we use homebrew's fltk:
+   Install homebrew: 			
+```
+   $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```
+   Install fltk: 			
+```
+   $ brew install fltk
+```
 
-1) For FLTK installation, we use homebrew's fltk:
-   Install homebrew: 			$ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-   Install fltk: 			$ brew install fltk
-
-2) Install other necessary library:	$ brew install python@2 pip gcc gtk+ pygtk —with-libglade && pip install pyopengl numpy
-
-3) Apply patch to the sourcefile:	$ patch -p0 -i MacOS.patch
-
-5) Copy the Makefile.MacOS to Makefile in the p4vasp root directory and in the src
-   directory:
-   cp Makefile.MacOS Makefile
-   cp src/Makefile.MacOS src/Makefile
-
+3) Install other necessary library:	
+```
+   $ brew install python@2 pip gcc gtk+ pygtk —with-libglade && pip install pyopengl numpy
+```
+4) Apply patch to the sourcefile:	
+```
+   $ patch -p0 -i MacOS.patch
+```
+5) Copy the Makefile.MacOS to Makefile in the p4vasp root directory and in the `src` and `odpdom` directory:
+```
+   $ cp Makefile.MacOS Makefile
+   $ cp odpdom/Makefile.MacOS odpdom/Makefile
+   $ cp src/Makefile.MacOS src/Makefile
+```
 6) Run make and install:
-   make local; make; make install
-
-7) The executable should located at ~/p4vasp/bin
+```
+   $ make local && make && make install
+```
+7) The executable should located at `~/p4vasp/bin`
 
 
 
@@ -98,25 +142,26 @@ Installation (MacOs)
 Starting:
 --------------------------
 
-Start with: p4v
+Start with: `p4v`
 
-Look at the documentation in the doc/intro/intro.html
-(or /usr/lib/p4vasp/doc/intro.html, when installed),
+Look at the documentation in the `doc/intro/intro.html`
+(or `/usr/lib/p4vasp/doc/intro.html`, when installed),
 if you need some clues how to deal with the p4v GUI.
 
 Some people prefer command-line tools and automatic scripts
 to a graphical interface. For those, there are some simple
-scripts in the utils directory (/usr/lib/p4vasp/utils).
+scripts in the utils directory (`/usr/lib/p4vasp/utils`).
 They are also a good example for the p4vasp-API.
 
 
-P4vasp package embeds the odpdom library, that is available also as a separate
-project (http://sourceforge.net/projects/odpdom) and a slightly modified version
-of the piddle library (piddle.sourceforge.net).
+P4vasp package embeds the odpdom library, that is available also as a [separate
+project](http://sourceforge.net/projects/odpdom) and a slightly modified version
+of the [piddle library](piddle.sourceforge.net).
 Both odpdom and piddle are available under the LGPL License (see
 odpdom/COPYING).
 
 This package as well may contain other packages (in ext directory) under various open-source licenses:
-fltk (www.fltk.org), sqlite (www.sqlite.org) and pysqlite (code.google.com/p/pysqlite).
+[fltk](www.fltk.org), [sqlite](www.sqlite.org) and [pysqlite](code.google.com/p/pysqlite).
 These packages are provided for convenience only to make the installation easier.
+
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Installation (local)
 1) Make sure you have all the dependencies.
    In Ubuntu you can do it with a supplied script: `install/install-ubuntu-dependencies.sh`
 2) If there are previous versions of p4vasp, uninstall them.
-   You can do it with the `uninstall.sh` residing in the P4VASP_HOME directory.
+   You can do it with the `uninstall.sh` residing in the `P4VASP_HOME` directory.
 3) Unpack the file:                
 ```
    $ tar -xvzf p4vasp-x.x.x.tgz
@@ -50,10 +50,7 @@ Installation (local)
 ```
    $ make local
 ```
-6) check and adjust the paths in
-```
-   $ install/Configuration.mk
-```
+6) check and adjust the paths in `install/Configuration.mk`
 7) Install:                        
 ```
    $ make install
@@ -90,7 +87,7 @@ Installation (global)
 ```
    $ make install
 ```
-x) If something goes wrong
+7) If something goes wrong
    - Run the diagnostic.py script, it may provide you with some hints.
    - Check FAQ
    - We can try to help you if you visit forum at www.p4vasp.at, please provide us with the output from diagnostic.py.

--- a/odpdom/Makefile.MacOS
+++ b/odpdom/Makefile.MacOS
@@ -1,0 +1,56 @@
+CPP     = g++-7
+LD      = g++-7
+LIBS    =
+LDFLAGS += -shared -L.
+FLAGS   = -DPY_DOMEXC_MODULE="\"xml.dom.\""
+          -DCHECK=5 \
+          -DVERBOSE=5 \
+
+#          -DNO_POS_CACHE
+#	  -DNO_THROW
+
+PYINCLUDE=`python -c "import sys;import os.path;print os.path.join(sys.prefix,\"include\",\"python\"+sys.version[:3])"`
+CFLAGS  += -fpic -g $(FLAGS) -I$(PYINCLUDE)  -Iinclude
+
+SWIGFLAGS = -python -c++ $(FLAGS)
+
+OBJECTS = string.o \
+          markText.o \
+	  Exceptions.o \
+	  Node.o \
+	  NodeSequences.o \
+	  Document.o \
+	  CharacterNodes.o \
+	  Element.o \
+	  parse.o
+
+#SWIG = ../../SWIG-1.3.16/swig -I../../SWIG-1.3.16/Lib -I../../SWIG-1.3.16/Lib/python 
+SWIG = swig
+
+all: _cODP.so
+
+cODP_wrap.cpp: include/ODP/NodeSequences.h      \
+               include/ODP/CharacterNodes.h     \
+	       include/ODP/Element.h include/ODP/Node.h \
+	       include/ODP/Document.h           \
+	       include/ODP/parse.h              \
+	       ODP.i
+	$(SWIG) $(SWIGFLAGS) -o cODP_wrap.cpp ODP.i
+
+_cODP.so : libODP.a cODP_wrap.o
+	$(LD) $(LDFLAGS) -o _cODP.so cODP_wrap.o -lODP $(LIBS)
+
+libODP.a: $(OBJECTS)
+	ar -r libODP.a $(OBJECTS)
+	ranlib libODP.a
+%.o:%.cpp
+	$(CPP) $(CFLAGS) -c $< -o $@
+
+cleanwrap:
+	-rm cODP_wrap.cpp
+clean:
+	-rm *.o
+	
+cleanall:clean
+	-rm *.so
+	-rm *.a

--- a/src/Makefile.MacOS
+++ b/src/Makefile.MacOS
@@ -1,9 +1,9 @@
-CPP=g++
-LD=gcc 
+-include Configuration.mk
 
-LIBS= -L. -lp4vasp -L../odpdom -lODP `fltk-config --use-gl --ldstaticflags` \
-	-lpthread /opt/local/lib/libpython.dylib /usr/lib/libc.dylib \
-	/usr/lib/libstdc++.6.dylib /usr/lib/libgcc_s.1.dylib
+CPP=g++-7
+LD=g++-7
+#CPP=icc
+#LD=icc
 
 FLAGS= -Wall -DPY_DOMEXC_MODULE="\"p4vasp.ODPdom.\"" \
        -DCHECK=1 \
@@ -11,15 +11,16 @@ FLAGS= -Wall -DPY_DOMEXC_MODULE="\"p4vasp.ODPdom.\"" \
        -DNO_GL_LISTS_S \
        -DNO_THREADS \
 
-CFLAGS= -g -O0 -fpic  -Wall $(FLAGS) `fltk-config --cxxflags` \
-	-I/opt/local/include/python2.4 -Iinclude -I../odpdom/include \
-	-I/usr/X11R6/include
-
+#       -DNO_THROW \
+#       -DSIMPLE_EXCEPTION \
+#       -DDRAWBUFFERHACK \
+#       -DNO_GL_LISTS \
+#       -DNO_GL_LISTS_S 
+#       -DNO_THREADS \
+       
 SWIGFLAGS= -python -c++  $(FLAGS) -I../odpdom/include -Iinclude
-
+      
 SWIG = swig
-
-LDFLAGS= -flat_namespace -undefined suppress
 
 OBJECTS= Exceptions.o \
 	 AtomtypesRecord.o \
@@ -47,7 +48,10 @@ OBJECTS= Exceptions.o \
 	 VisPrimitiveDrawer.o \
 	 VisBackEvent.o 
 
+
+
 PYLIBOBJECTS = $(OBJECTS) cp4vasp_wrap.o
+	 
 
 all: _cp4vasp.so
 
@@ -55,22 +59,28 @@ all: _cp4vasp.so
 	$(CPP) $(CFLAGS) -c $< -o $@
 %.o: %.c 
 	$(CPP) $(CFLAGS) -c $< -o $@
-#cp4vasp_wrap.cpp: cp4vasp.i
-#	$(SWIG) $(SWIGFLAGS) -o cp4vasp_wrap.cpp cp4vasp.i 
+cp4vasp_wrap.cpp: cp4vasp.i
+	$(SWIG) $(SWIGFLAGS) -o cp4vasp_wrap.cpp cp4vasp.i 
 	
+#_cp4vasp.so: $(PYLIBOBJECTS)
+#	$(LD) $(LDFLAGS) -o _cp4vasp.so $(PYLIBOBJECTS) $(LIBS) 
 _cp4vasp.so: libp4vasp.a cp4vasp_wrap.o
-	$(LD) $(LDFLAGS) -o _cp4vasp.so cp4vasp_wrap.o -bundle $(LIBS) 
+	$(LD) $(LDFLAGS) -o _cp4vasp.so cp4vasp_wrap.o -lp4vasp $(LIBS) -L/usr/local/opt/python@2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config -lpython2.7 -ldl -framework CoreFoundation 
 
 testprog1: testprog1.o libp4vasp.a
-	$(LD) -o testprog1 testprog1.o $(LIBS)
+	$(LD) -o testprog1 testprog1.o -lp4vasp.a $(LIBS)
 testprog2: testprog2.o libp4vasp.a
-	$(LD) -o testprog2 testprog2.o $(LIBS)
+	$(LD) -o testprog2 testprog2.o -lp4vasp $(LIBS)
 viewer1: viewer1.o libp4vasp.a
-	$(LD) -o viewer1 viewer1.o $(LIBS)
+	$(LD) -o viewer1 viewer1.o -L. -lp4vasp $(LIBS)
 viewer2: viewer2.o libp4vasp.a
-	$(LD) -o viewer2 viewer2.o $(LIBS) -ldl
+	$(LD) -o viewer2 viewer2.o -L. -lp4vasp $(LIBS) -ldl
 viewer3: viewer3.o libp4vasp.a
-	$(LD) -o viewer3 viewer3.o $(LIBS)
+	$(LD) -o viewer3 viewer3.o -L. -lp4vasp $(LIBS)
+#testdombug: testdombug.o libp4vasp.a
+#	$(LD) -o testdombug testdombug.o -L. -lp4vasp $(LIBS)
+#viewer3: viewer3.o $(OBJECTS)
+#	$(LD) -static -o viewer3 viewer3.o $(OBJECTS) $(LIBS) -ldl
 
 libp4vasp.a: $(OBJECTS)
 	ar -r libp4vasp.a $(OBJECTS)
@@ -90,3 +100,7 @@ cleanall: clean
 	-rm testprog*
 	-rm viewer1
 	-rm viewer2
+	-rm *.tmp
+	-rm *.pyc
+	-rm *.pyo
+	-rm *~

--- a/src/Makefile.MacOS
+++ b/src/Makefile.MacOS
@@ -65,7 +65,7 @@ cp4vasp_wrap.cpp: cp4vasp.i
 #_cp4vasp.so: $(PYLIBOBJECTS)
 #	$(LD) $(LDFLAGS) -o _cp4vasp.so $(PYLIBOBJECTS) $(LIBS) 
 _cp4vasp.so: libp4vasp.a cp4vasp_wrap.o
-	$(LD) $(LDFLAGS) -o _cp4vasp.so cp4vasp_wrap.o -lp4vasp $(LIBS) -L/usr/local/opt/python@2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/config -lpython2.7 -ldl -framework CoreFoundation 
+	$(LD) $(LDFLAGS) -o _cp4vasp.so cp4vasp_wrap.o -lp4vasp $(LIBS) `python-config --ldflags`
 
 testprog1: testprog1.o libp4vasp.a
 	$(LD) -o testprog1 testprog1.o -lp4vasp.a $(LIBS)

--- a/vinfo.py
+++ b/vinfo.py
@@ -1,0 +1,5 @@
+name       ="p4vasp"
+version    ="develop-brance"
+release    ="Null"
+build_date ="April 28 2018"
+


### PR DESCRIPTION
I have found a way to successfully compile p4vasp on MacOS (10.13.4)

The main problem I encountered is the installation of FLTK which can be easily avoided by using the precompiled version maintained by [homebrew](https://brew.sh/).

Also <GL/gl.h> does not work on MacOS. By changing all "<GL/gl.h>" to "<openGL/gl.h>" and proper linking with python's configuration `python-config --ldflags`, _cp4vasp.so can be successfully compiled.

BTW, some minor modifications has been made to the README.md file.