### PR TITLE
set calls to python interpreter explicitly as python2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ P4V           = p4v
 
 all: p4vasp
 local:
-	cd install && python configure.py local
+	cd install && python2 configure.py local
 config:
-	cd install && python configure.py
+	cd install && python2 configure.py
 p4vasp: p4vasp_config uninstallsh fltk appletlist
 	cd odpdom && $(MAKE) libODP.a	
 	cd src && $(MAKE)
@@ -67,9 +67,9 @@ launcher:
 	echo "#export APPMENU_DISPLAY_BOTH=1" >>$(P4V)
 	echo "export UBUNTU_MENUPROXY=0" >>$(P4V)
 	echo "export P4VASP_HOME="$(P4VASP_HOME) >> $(P4V)
-	echo "exec python "$(BINDIR)"/p4v.py \"\$$@\"" >>$(P4V)
+	echo "exec python2 "$(BINDIR)"/p4v.py \"\$$@\"" >>$(P4V)
 appletlist:
-	cd install && python makeappletlist.py
+	cd install && python2 makeappletlist.py
 bashrc:setenvironment
 	echo "" >> ~/.bashrc
 	cat $(SETENVIRONMENT) >> ~/.bashrc

--- a/diagnostic.py
+++ b/diagnostic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 
 print "p4vasp Diagnostics"

--- a/lib/p4vasp/ConvexShape.py
+++ b/lib/p4vasp/ConvexShape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from math import *
 from p4vasp.paint3d.OpenGLPaint3D import *
 from p4vasp.paint3d.PovrayPaint3D import *

--- a/lib/p4vasp/GraphCanvas.py
+++ b/lib/p4vasp/GraphCanvas.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/GraphCanvas_gtk1.py
+++ b/lib/p4vasp/GraphCanvas_gtk1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/PhononsCalculation.py
+++ b/lib/p4vasp/PhononsCalculation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import p4vasp.matrix as p4m
 import numpy as np

--- a/lib/p4vasp/Property.py
+++ b/lib/p4vasp/Property.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # HappyDoc:docStringFormat='ClassicStructuredText'
 #

--- a/lib/p4vasp/SQLSystemPM.py
+++ b/lib/p4vasp/SQLSystemPM.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # HappyDoc:docStringFormat='ClassicStructuredText'
 #

--- a/lib/p4vasp/Selection.py
+++ b/lib/p4vasp/Selection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/StructureWindow.py
+++ b/lib/p4vasp/StructureWindow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # HappyDoc:docStringFormat='ClassicStructuredText'
 #

--- a/lib/p4vasp/SystemPM.py
+++ b/lib/p4vasp/SystemPM.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # HappyDoc:docStringFormat='ClassicStructuredText'
 #
@@ -99,7 +99,7 @@ Following calculation properties are available:
 
   example:
 
-    #!/usr/bin/python
+    #!/usr/bin/python2
     from p4vasp.SystemPM import *
     s=XMLSystemPM('vasprun.xml')
     poscar=s.INITIAL_STRUCTURE

--- a/lib/p4vasp/applet/Applet.py
+++ b/lib/p4vasp/applet/Applet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/AppletTree.py
+++ b/lib/p4vasp/applet/AppletTree.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/AppletTree_old.py
+++ b/lib/p4vasp/applet/AppletTree_old.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/BuilderApplet.py
+++ b/lib/p4vasp/applet/BuilderApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/CommitApplet.py
+++ b/lib/p4vasp/applet/CommitApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/DBApplet.py
+++ b/lib/p4vasp/applet/DBApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/DielectricApplet.py
+++ b/lib/p4vasp/applet/DielectricApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/EditSubZMatApplet.py
+++ b/lib/p4vasp/applet/EditSubZMatApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/ElectronicApplet.py
+++ b/lib/p4vasp/applet/ElectronicApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/ElectronicControlApplet.py
+++ b/lib/p4vasp/applet/ElectronicControlApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/EnergyConvergenceApplet.py
+++ b/lib/p4vasp/applet/EnergyConvergenceApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/ExportApplet.py
+++ b/lib/p4vasp/applet/ExportApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/ForcesConvergenceApplet.py
+++ b/lib/p4vasp/applet/ForcesConvergenceApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/GraphWindowApplet.py
+++ b/lib/p4vasp/applet/GraphWindowApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/InfoApplet.py
+++ b/lib/p4vasp/applet/InfoApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/KpointsViewerApplet.py
+++ b/lib/p4vasp/applet/KpointsViewerApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/LatticeApplet.py
+++ b/lib/p4vasp/applet/LatticeApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/LocalPotentialApplet.py
+++ b/lib/p4vasp/applet/LocalPotentialApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/MeasureApplet.py
+++ b/lib/p4vasp/applet/MeasureApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/MoveApplet.py
+++ b/lib/p4vasp/applet/MoveApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/MultiplyCellApplet.py
+++ b/lib/p4vasp/applet/MultiplyCellApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/NewApplet.py
+++ b/lib/p4vasp/applet/NewApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/PhononApplet.py
+++ b/lib/p4vasp/applet/PhononApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/PhononDispersionApplet.py
+++ b/lib/p4vasp/applet/PhononDispersionApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/RotateApplet.py
+++ b/lib/p4vasp/applet/RotateApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/STMWindowApplet.py
+++ b/lib/p4vasp/applet/STMWindowApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/STMWindowControlApplet.py
+++ b/lib/p4vasp/applet/STMWindowControlApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/SelForcesConvergenceApplet.py
+++ b/lib/p4vasp/applet/SelForcesConvergenceApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/SelectionApplet.py
+++ b/lib/p4vasp/applet/SelectionApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/ShowHideControlApplet.py
+++ b/lib/p4vasp/applet/ShowHideControlApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/StructureApplet.py
+++ b/lib/p4vasp/applet/StructureApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/StructureWindowApplet.py
+++ b/lib/p4vasp/applet/StructureWindowApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/StructureWindowControlApplet.py
+++ b/lib/p4vasp/applet/StructureWindowControlApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/applet/VACApplet.py
+++ b/lib/p4vasp/applet/VACApplet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/db.py
+++ b/lib/p4vasp/db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from string import *
 from UserList import *

--- a/lib/p4vasp/message.py
+++ b/lib/p4vasp/message.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # HappyDoc:docStringFormat='ClassicStructuredText'
 #

--- a/lib/p4vasp/piddle/piddleGTK/tests.py_
+++ b/lib/p4vasp/piddle/piddleGTK/tests.py_
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 
 """Test script for piddle.GTK.
 

--- a/lib/p4vasp/piddle/piddleGTK2p4/core.py
+++ b/lib/p4vasp/piddle/piddleGTK2p4/core.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 """Slightly modified PIDDLE canvas implementations for PyGTK.
 
 The real documentation is in piddleGTK.

--- a/lib/p4vasp/piddle/piddleGTK2p4/tests.py_
+++ b/lib/p4vasp/piddle/piddleGTK2p4/tests.py_
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 
 """Test script for piddle.GTK.
 

--- a/lib/p4vasp/piddle/piddleGTKp4/tests.py_
+++ b/lib/p4vasp/piddle/piddleGTKp4/tests.py_
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#!/usr/bin/env python2
 
 """Test script for piddle.GTK.
 

--- a/lib/p4vasp/sellang.py
+++ b/lib/p4vasp/sellang.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/setupstore.py
+++ b/lib/p4vasp/setupstore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/lib/p4vasp/store.py
+++ b/lib/p4vasp/store.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # HappyDoc:docStringFormat='ClassicStructuredText'
 #

--- a/lib/p4vasp/util.py
+++ b/lib/p4vasp/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #
 # HappyDoc:docStringFormat='ClassicStructuredText'
 #

--- a/odpdom/Makefile
+++ b/odpdom/Makefile
@@ -9,7 +9,7 @@ FLAGS   = -DPY_DOMEXC_MODULE="\"xml.dom.\""
 #          -DNO_POS_CACHE
 #	  -DNO_THROW
 
-PYINCLUDE=`python -c "import sys;import os.path;print os.path.join(sys.prefix,\"include\",\"python\"+sys.version[:3])"`
+PYINCLUDE=`python2 -c "import sys;import os.path;print os.path.join(sys.prefix,\"include\",\"python\"+sys.version[:3])"`
 CFLAGS  += -fpic -g $(FLAGS) -I$(PYINCLUDE)  -Iinclude
 
 SWIGFLAGS = -python -c++ $(FLAGS)

--- a/odpdom/setup.py
+++ b/odpdom/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from distutils.core import setup, Extension
 from glob import *

--- a/p4v.py
+++ b/p4v.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (C) 2003 Orest Dubay <orest.dubay@univie.ac.at>
 
 from __future__ import generators

--- a/src/Configuration.mk
+++ b/src/Configuration.mk
@@ -1,6 +1,6 @@
-LIBS=  -L../odpdom -lODP `python fltk-config.py --use-gl --ldstaticflags` -lpthread
+LIBS=  -L../odpdom -lODP `python2 fltk-config.py --use-gl --ldstaticflags` -lpthread
 CFLAGS?= -g -Wall
-CFLAGS+= -fpic $(FLAGS) `python fltk-config.py --cxxflags` -I$(PYINCLUDE) \
+CFLAGS+= -fpic $(FLAGS) `python2 fltk-config.py --cxxflags` -I$(PYINCLUDE) \
         -Iinclude -I../odpdom/include
-PYINCLUDE=`python -c "import sys;import os.path;print os.path.join(sys.prefix,\"include\",\"python\"+sys.version[:3])"`
+PYINCLUDE=`python2 -c "import sys;import os.path;print os.path.join(sys.prefix,\"include\",\"python\"+sys.version[:3])"`
 LDFLAGS+= -shared -L.

--- a/src/fltk-config.py
+++ b/src/fltk-config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import os.path

--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Copyright (C) 2012 Orest Dubay <dubay@danubiananotech.com>
 import unittest
 import testSystemPM

--- a/test/testColladaPaint3D.py
+++ b/test/testColladaPaint3D.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import unittest
 from p4vasp.paint3d.ColladaPaint3D import *
 from p4vasp.matrix import Vector

--- a/test/testIsosurface.py
+++ b/test/testIsosurface.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import unittest
 from p4vasp.isosurface import *
 from cp4vasp import *

--- a/test/testPovrayPaint3D.py
+++ b/test/testPovrayPaint3D.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import unittest
 from p4vasp.paint3d.PovrayPaint3D import *
 from p4vasp.matrix import Vector

--- a/utils/CHGCAR2cube.py
+++ b/utils/CHGCAR2cube.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  This utility is a part of p4vasp package.
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)

--- a/utils/bandfolding.py
+++ b/utils/bandfolding.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/bands.py
+++ b/utils/bands.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/bondevolution.py
+++ b/utils/bondevolution.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/dos.py
+++ b/utils/dos.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/extract.py
+++ b/utils/extract.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/final2poscar.py
+++ b/utils/final2poscar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/final2xyz.py
+++ b/utils/final2xyz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/finaldist.py
+++ b/utils/finaldist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/getenergy.py
+++ b/utils/getenergy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from p4vasp.SystemPM import *
 from glob import glob

--- a/utils/groups_distance.py
+++ b/utils/groups_distance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/initial2poscar.py
+++ b/utils/initial2poscar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/initial2xyz.py
+++ b/utils/initial2xyz.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/ipr.py
+++ b/utils/ipr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/isosurfaceexporter.py
+++ b/utils/isosurfaceexporter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/kpoints_all.py
+++ b/utils/kpoints_all.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/minforce_poscar.py
+++ b/utils/minforce_poscar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/mirror.py
+++ b/utils/mirror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/nanotube.py
+++ b/utils/nanotube.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 import sys
 from math import *

--- a/utils/notselective.py
+++ b/utils/notselective.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/povraysphere.py
+++ b/utils/povraysphere.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/remove.py
+++ b/utils/remove.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/replicate.py
+++ b/utils/replicate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/scanPotcar.py
+++ b/utils/scanPotcar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 from string import *
 from glob import glob
 import os.path

--- a/utils/select.py
+++ b/utils/select.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 #  p4vasp is a GUI-program and a library for processing outputs of the
 #  Vienna Ab-inition Simulation Package (VASP)
 #  (see http://cms.mpi.univie.ac.at/vasp/Welcome.html)

--- a/utils/sortatomsZ.py
+++ b/utils/sortatomsZ.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 from p4vasp.Structure import *
 from sys import argv


### PR DESCRIPTION
Would you consider applying this proposed modifications?

As more distros are choosing Python 3 as the default  `python` interpreter this will reduce required modifications to compile/build/run on those. 

It won't break usage on the rest of the distros as the  `python2` alias also exist always.